### PR TITLE
Refactor to promises

### DIFF
--- a/docs/src/_layouts/default.webc
+++ b/docs/src/_layouts/default.webc
@@ -48,7 +48,7 @@
 
         [Heartml is open source](https://github.com/heartml/heartml), licensed MIT
 
-        “Callee” character created by Glorianna White
+        “Callee” character created by Mikey <3
 
         Color scheme inspired by [Search Lights](https://github.com/finnjames/search-lights) by Finn James
       </template>

--- a/docs/src/index.webc
+++ b/docs/src/index.webc
@@ -174,6 +174,14 @@ class MyComponent extends HeartElement {
 </playground-ide>
 <copy-button from="rename-callee"></copy-button>
 
+<template webc:type="11ty" 11ty:type="md">
+
+  ### Declarative Custom Elements (DCEs)
+
+  Heartml lets you define custom elements **declaratively** directly in your HTML using `heart-ml` tags. This is particularly useful for co-locating components with specific use cases right in the contexts where they'll be used.
+
+</template>
+
 <playground-ide id="phone-number-input">
   <script webc:keep type="sample/html" filename="index.html">
 
@@ -197,8 +205,7 @@ class MyComponent extends HeartElement {
     declarative-events='["input"]'
   >
     <script type="module">
-      const DeclarativeHeartElement = await customElements.whenDefined("heart-ml")
-      class NameChange extends DeclarativeHeartElement {
+      class NameChange extends (await customElements.whenDefined("heart-ml")) {
         start() {
           this.name = ""
         }
@@ -221,7 +228,7 @@ class MyComponent extends HeartElement {
 
 ### Heartml Module Files (SFCs)
 
-When you're ready to write a **Single-File Component** that's not purely JavaScript, here comes `.heartml`. You can import and bundle `.heartml` files via [esbuild](https://github.com/whitefusionhq/esbuild-plugin-html-modules), or simply use the `<heart-module>` custom element to load them up in any "buildless" environment.
+Moving a step up from DCEs, you can author `.heartml` files—a **Single-File Component** format which starts with pure HTML. You can import and bundle `.heartml` files via [esbuild](https://github.com/whitefusionhq/esbuild-plugin-html-modules) or alternatively use the `<heart-module>` custom element to load them up in any "buildless" environment.
 
 </template>
 

--- a/docs/src/index.webc
+++ b/docs/src/index.webc
@@ -191,13 +191,14 @@ class MyComponent extends HeartElement {
   </name-change>
 
   <!-- Ooo, declarative! -->
-  <heart-ml tag="name-change"
+  <heart-ml tag-name="name-change"
     properties='{ "name": {} }'
     declarative-effects='{ "light": true }'
     declarative-events='["input"]'
   >
     <script type="module">
-      class NameChange extends HeartElement {
+      const DeclarativeHeartElement = await customElements.whenDefined("heart-ml")
+      class NameChange extends DeclarativeHeartElement {
         start() {
           this.name = ""
         }
@@ -206,7 +207,7 @@ class MyComponent extends HeartElement {
           this.name = event.target.value.replace(/[a-zA-Z]*/g, "")
         }
       }
-      NameChange.hoist()
+      NameChange.define()
     &lt;/script>
   </heart-ml>
 </body>

--- a/example/counter.html
+++ b/example/counter.html
@@ -22,16 +22,19 @@
 
 <h1>Counters</h1>
 
-<heart-ml tag="counter-widget" properties='{"count": {}}' declarative-effects='{"shadow": true }' declarative-events='["click"]'>
+<heart-ml tag-name="counter-widget" properties='{"count": {}}' declarative-effects='{"shadow": true }' declarative-events='["click"]'>
   <script type="module">
-    const globalCount = Heartml.signal(20)
+    const DeclarativeHeartElement = await customElements.whenDefined("heart-ml")
+    const { signal } = DeclarativeHeartElement
+    const globalCount = signal(20)
+
     class   CounterWidget 
-      extends   HeartElement { // test weird whitespace
+      extends   DeclarativeHeartElement { // test weird whitespace
       start() { this.count = globalCount }
       increment(event) { this.count++ }
       decrement(event) { this.count-- }
     }
-    CounterWidget.hoist()
+    CounterWidget.define()
   </script>
 </heart-ml>
 

--- a/example/index.html
+++ b/example/index.html
@@ -55,7 +55,7 @@
   <hr />
 
   <heart-ml
-    tag="im-declarative"
+    tag-name="im-declarative"
     properties='{ "label": {}, "capsLabel": { "memoize": true }, "num": {} }'
     declarative-effects='{ "light": true, "shadow": true }'
     declarative-events='["click"]'
@@ -75,6 +75,7 @@
       </style>
     </template>
     <script type="module">
+      const HeartElement = await customElements.whenDefined("heart-ml")
       class ImDeclarative extends HeartElement {
         start() {
           this.num = 3
@@ -93,7 +94,7 @@
           alert("🎉")
         }
       }
-      ImDeclarative.hoist()
+      ImDeclarative.define()
     </script>
   </heart-ml>
 

--- a/example/js/example.js
+++ b/example/js/example.js
@@ -4,7 +4,6 @@ import "./pluginsetup.js"
 import "./BlahGoo.js"
 import "../../src/DeclarativeHeartElement.js"
 import "../../src/utils/HeartModule.js"
-HeartElement.hoist()
 
 const { directives } = Heartml.plugins.declarativeEffects
 
@@ -86,6 +85,8 @@ export class TestMe extends HeartElement {
     return this._blahGoo.hello
   }
 }
+
+export { HeartElement }
 
 // setTimeout(() => {
 //   document.body.innerHTML = "done!"

--- a/example/js/example.js
+++ b/example/js/example.js
@@ -2,7 +2,7 @@
 import Heartml, { HeartElement } from "../../src/heartml.js"
 import "./pluginsetup.js"
 import "./BlahGoo.js"
-import "../../src/DeclarativeHeartElement.js"
+import "../../src/utils/DeclarativeHeartElement.js"
 import "../../src/utils/HeartModule.js"
 
 const { directives } = Heartml.plugins.declarativeEffects
@@ -33,7 +33,7 @@ export class TestMe extends HeartElement {
       }
     }
 
-    this.confetti = "orange"
+    this.dashed = "orange"
 
     this.define("test-me")
   }

--- a/example/js/pluginsetup.js
+++ b/example/js/pluginsetup.js
@@ -1,14 +1,14 @@
 //@ts-check
 import Heartml from "../../src/heartml.js"
 
-Heartml.plugins.confetti = {
+Heartml.plugins.dashed = {
   connected(element) {
-    const { confetti } = element.constructor
+    const { dashed } = element.constructor
     setTimeout(() => {
       Object.assign(element.style, {
         display: "block",
         padding: "1.25rem",
-        border: `8px dashed ${confetti}`
+        border: `8px dashed ${dashed}`
       })
     }, 700)
   }

--- a/example/mods/counter.heartml
+++ b/example/mods/counter.heartml
@@ -1,7 +1,7 @@
 <template>
-  <button host-event="click#decrement">-</button>
+  <button host-event="click#decrement">Less -</button>
   <strong host-effect="@textContent=.count" style="display: inline-block; width: 4rem">0</strong>
-  <button host-event="click#increment">+</button>
+  <button host-event="click#increment">+ More</button>
 </template>
 
 <style>

--- a/example/mods/counter.heartml
+++ b/example/mods/counter.heartml
@@ -10,7 +10,7 @@
 </style>
 
 <script type="module">
-  class Counter extends HeartElement {
+  class Counter extends (await customElements.whenDefined("heart-ml")) {
     static template = import.meta.document
     static properties={"count": {}}
     static declarativeEffects={"shadow": true }

--- a/example/todoapp.html
+++ b/example/todoapp.html
@@ -138,7 +138,7 @@ logic.
 -->
 
 <heart-ml
-  tag="todo-list"
+  tag-name="todo-list"
   properties='{
     "todosState": { "attribute": "todos-state" },
     "completedCount": { "memoize": true },
@@ -156,7 +156,7 @@ logic.
   }'
 >
   <script type="module">
-    class TodoList extends HeartElement {
+    class TodoList extends (await customElements.whenDefined("heart-ml")) {
       start() {
         this.todosState = []
       }
@@ -191,12 +191,12 @@ logic.
       }
     }
 
-    TodoList.hoist()
+    TodoList.define()
   </script>
 </heart-ml>
 
 <heart-ml
-  tag="todo-item"
+  tag-name="todo-item"
   properties='{
     "itemid": {},
     "completed": {}
@@ -214,6 +214,8 @@ logic.
       <input type="checkbox" host-effect="@checked = .completed" host-event="change#check" />
       <slot host-effect="$styleMap(.checkedStyles)"></slot>
     </label>
+  </template>
+  <template data-css>
     <style>
       input {
         margin-inline-end: 1rem;
@@ -228,7 +230,7 @@ logic.
   </template>
 
   <script type="module">
-    class TodoItem extends HeartElement {
+    class TodoItem extends (await customElements.whenDefined("heart-ml")) {
       start() {
         this.itemid = 0
         /**
@@ -271,7 +273,7 @@ logic.
       }
     }
 
-    TodoItem.hoist()
+    TodoItem.define()
   </script>
 </heart-ml>
 

--- a/example/todoapp.html
+++ b/example/todoapp.html
@@ -15,7 +15,6 @@
       font-weight: 900;
     }
   </style>
-  <script src="/js/cdn-style-app.js" defer></script>
   <script>
     /**
      * Shorthand to let you create an element and assign properties in one go
@@ -276,6 +275,8 @@ logic.
     TodoItem.define()
   </script>
 </heart-ml>
+
+<script src="/js/cdn-style-app.js"></script>
 
 <script>
   // Declarative Shadow DOM (DSD) polyfill

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "main": "dist/heartml.cdn.js",
   "exports": {
     ".": "./dist/heartml.js",
-    "./DeclarativeHeartElement.js": "./dist/DeclarativeHeartElement.js",
-    "./utils/HeartModule.js": "./dist/utils/HeartModule.js",
+    "./utils/*": "./dist/utils/*",
     "./src/*": "./src/*"
   },
   "files": [

--- a/src/DeclarativeHeartElement.js
+++ b/src/DeclarativeHeartElement.js
@@ -1,65 +1,100 @@
 //@ts-check
-import Heartml, { HeartElement } from "./heartml.js"
+import Heartml, { HeartElement, css, html } from "./heartml.js"
+import { signal, computed, effect, batch, Signal } from "@preact/signals-core"
 
-class DeclarativeHeartElement extends HTMLElement {
+class DeclarativeHeartElement extends HeartElement {
   static {
+    Object.assign(this, {
+      css,
+      html,
+      signal,
+      computed,
+      effect,
+      batch,
+      Signal
+    })
+
     customElements.define("heart-ml", this)
   }
 
-  camelCase(str) {
+  static modulePromises = {}
+
+  static async define(tagName = null) {
+    if (!tagName) {
+      let modulePromise
+      
+      // We'll either save a promise now to be resolved later, or get a promise to resolve now
+      // that was supplied by the connectedCallback of the declarative instance.
+      if (!DeclarativeHeartElement.modulePromises[this.name]) {
+        let callback;
+        modulePromise = DeclarativeHeartElement.modulePromises[this.name] = new Promise((resolve, reject) => {
+          callback = resolve
+        })
+        DeclarativeHeartElement.modulePromises[this.name] = callback
+      } else {
+        modulePromise = DeclarativeHeartElement.modulePromises[this.name]
+      }
+
+      const el = await modulePromise
+
+      /** @type {HTMLTemplateElement} */
+      const template = el.querySelector("template[data-html]")
+      /** @type {HTMLTemplateElement} */
+      const stylesTemplate = el.querySelector("template[data-css]")
+      if (template) this.template = template.content
+      if (stylesTemplate) this.styles = stylesTemplate.content.querySelector("style")
+      
+      for (const attribute of el.attributes) {
+        const pluginName = this.camelCase(attribute.name)
+        if (pluginName in Heartml.plugins) {
+          this[pluginName] = JSON.parse(attribute.value)
+        }
+      }
+      
+      super.define(el.getAttribute("tag-name"))
+    } else {
+      super.define(tagName)
+    }
+  }
+
+  static camelCase(str) {
     // from: https://stackoverflow.com/a/46116986/551775
     return str
       .split('-')
       .reduce((a, b) => a + b.charAt(0).toUpperCase() + b.slice(1))
   }
 
-  handleEvent(event) {
-    const tagName = this.getAttribute("tag")
-
-    if (!customElements.get(tagName)) {
-      const scriptTag = this.querySelector("script")
-      const globalName = scriptTag.textContent.match(/class\s+(\w+)\s+extends\s+/)?.[1]
-
-      if (!globalName) {
-        console.warn(`A "class [Name] extends" pattern could not be found in the module script.`)
-        console.debug(this)
-        return
-      }
-
-      if (event.detail.globalClassName !== globalName) return;
-
-      const newCE = globalThis[globalName]
-
-      if (!newCE) {
-        console.warn(`The "${globalName}" class could not be found in the global scope.`)
-        console.debug(this)
-        return
-      }
-
-      /** @type {HTMLTemplateElement} */
-      const template = this.querySelector("template[data-html]")
-      /** @type {HTMLTemplateElement} */
-      const stylesTemplate = this.querySelector("template[data-css]")
-      if (template) newCE.template = template.content
-      if (stylesTemplate) newCE.styles = stylesTemplate.content.querySelector("style")
-      
-      for (const attribute of this.attributes) {
-        const pluginName = this.camelCase(attribute.name)
-        if (pluginName in Heartml.plugins) {
-          newCE[pluginName] = JSON.parse(attribute.value)
-        }
-      }
-      
-      newCE.define(tagName)
-    }
-  }
-
   connectedCallback() {
-    document.addEventListener("heartml:hoist", this)
-  }
+    if (this.localName === "heart-ml") {
+      // Code path for declarative elements
+      setTimeout(() => {
+        // Find the class name within the module script
+        const scriptTag = this.querySelector("script[type=module]")
+        const globalName = scriptTag.textContent.match(/class\s+(\w+)\s+extends\s+/)?.[1]
 
-  disconnectedCallback() {
-    document.removeEventListener("heartml:hoist", this)
+        if (!globalName) {
+          console.warn(`A "class [Name] extends" pattern could not be found in the module script.`)
+          console.debug(this)
+          return
+        }
+
+        this.setAttribute("global-name", globalName)
+
+        // We either resolve a promise already created by the component's `complete` static
+        // method, or save a promise to be resolved later:
+        if (DeclarativeHeartElement.modulePromises[globalName]) {
+          // This is likely the route taken
+          DeclarativeHeartElement.modulePromises[globalName](this)
+        } else {
+          // This only happens if there's some delay within the module script
+          DeclarativeHeartElement.modulePromises[globalName] = new Promise((resolve, reject) => {
+            resolve(this)
+          })
+        }
+      })
+    } else {
+      super.connectedCallback()
+    }
   }
 }
 

--- a/src/core.js
+++ b/src/core.js
@@ -88,22 +88,6 @@ export class HeartElement extends HTMLElement {
     customElements.define(tagName, this)
   }
 
-  /**
-   * Add this class to the global object (aka `window`). For declarative elements,
-   * an event is dispatched so that the parent `heart-ml` element can complete setup.
-   */
-  static hoist() {
-    globalThis[this.name] = this
-
-    if (this.name !== "HeartElement") {
-      setTimeout(() => {
-        document.dispatchEvent(
-          new CustomEvent("heartml:hoist", { detail: { globalClassName: this.name } })
-        )
-      })
-    }
-  }
-
   constructor() {
     super()
 

--- a/src/heartml.cdn.js
+++ b/src/heartml.cdn.js
@@ -1,23 +1,11 @@
-import Heartml, * as HeartmlExports from "./heartml.js"
+import Heartml, { HeartElement, HeartLifecycle } from "./heartml.js"
 import DeclarativeHeartElement from "./DeclarativeHeartElement.js"
 import HeartModule from "./utils/HeartModule.js"
-import { signal, computed, effect, batch, Signal } from "@preact/signals-core"
-
-globalThis.Heartml = Heartml
 
 Object.assign(globalThis, {
-  HeartElement: HeartmlExports.HeartElement,
-  HeartLifecycle: HeartmlExports.HeartLifecycle,
+  Heartml,
+  HeartElement,
+  HeartLifecycle,
   DeclarativeHeartElement,
   HeartModule
-})
-
-Object.assign(globalThis.Heartml, {
-  css: HeartmlExports.css,
-  html: HeartmlExports.html,
-  signal,
-  computed,
-  effect,
-  batch,
-  Signal
 })

--- a/src/heartml.cdn.js
+++ b/src/heartml.cdn.js
@@ -1,5 +1,5 @@
 import Heartml, { HeartElement, HeartLifecycle } from "./heartml.js"
-import DeclarativeHeartElement from "./DeclarativeHeartElement.js"
+import DeclarativeHeartElement from "./utils/DeclarativeHeartElement.js"
 import HeartModule from "./utils/HeartModule.js"
 
 Object.assign(globalThis, {

--- a/src/utils/DeclarativeHeartElement.js
+++ b/src/utils/DeclarativeHeartElement.js
@@ -1,5 +1,5 @@
 //@ts-check
-import Heartml, { HeartElement, css, html } from "./heartml.js"
+import Heartml, { HeartElement, css, html } from "../heartml.js"
 import { signal, computed, effect, batch, Signal } from "@preact/signals-core"
 
 class DeclarativeHeartElement extends HeartElement {

--- a/src/utils/HeartModule.js
+++ b/src/utils/HeartModule.js
@@ -46,11 +46,13 @@ export default __import_meta_document
     return importPromise
   }
 
+  static {
+    customElements.define("heart-module", HeartModule)
+  }
+
   connectedCallback() {
     this.constructor.import(this.getAttribute("src"), this)
   }
 }
-
-customElements.define("heart-module", HeartModule)
 
 export default HeartModule


### PR DESCRIPTION
This Promise-based approach to setup of DCEs (Declarative Custom Elements) is cleaner than the events system which proceeded it, and the CDN import/export is cleaner too. Using top-level await to define a DCE after the `heart-ml` tag is initialized also smooths things out (no global import timing issue).